### PR TITLE
PS-9784: Fixes gcc-15 compilation warnings

### DIFF
--- a/db/blob/blob_file_meta.h
+++ b/db/blob/blob_file_meta.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <cassert>
+#include <cstdint>
 #include <iosfwd>
 #include <memory>
 #include <string>

--- a/include/rocksdb/trace_record.h
+++ b/include/rocksdb/trace_record.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>

--- a/include/rocksdb/write_batch_base.h
+++ b/include/rocksdb/write_batch_base.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 
 #include "rocksdb/attribute_groups.h"
 #include "rocksdb/rocksdb_namespace.h"


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9784

Adds #include <cstdint> directive wherever it is necessary.